### PR TITLE
Fix

### DIFF
--- a/lib/backend/api/gibolt.py
+++ b/lib/backend/api/gibolt.py
@@ -39,7 +39,7 @@ rest(
 
 rest(
     Role,
-    methods=['GET', 'PUT', 'POST', 'DELETE'],
+    methods=['GET', 'PATCH', 'POST', 'PUT', 'DELETE'],
     name='roles',
     query=lambda query: query.filter(
         Role.circle_id == (request.values.get('circle_id'))

--- a/lib/frontend/src/actions/meetings.js
+++ b/lib/frontend/src/actions/meetings.js
@@ -29,6 +29,11 @@ export const updateMeeting = (data, dataType) => ({
   dataType,
 })
 
+export const partialUpdateMeeting = data => ({
+  type: 'MEETING_PARTIAL_UPDATE',
+  data,
+})
+
 export const updateMeetingAttendees = (name, checked) => ({
   type: 'MEETING_UPDATE_ATTENDEES',
   name,
@@ -257,7 +262,7 @@ export const submitOrUpdateReport = (
   }
   const meeting = formatMeeting(json.objects[0])
   dispatch(disableEdition(editionDisabled))
-  dispatch(setResults(meeting, 'meeting'))
+  dispatch(partialUpdateMeeting(meeting))
 }
 
 async function fetchRoleItems(role) {

--- a/lib/frontend/src/actions/roles.js
+++ b/lib/frontend/src/actions/roles.js
@@ -180,7 +180,7 @@ export const updateRole = (roleId, data, history) => async dispatch => {
   let response, json
   try {
     response = await fetch(`/api/roles/${roleId}`, {
-      method: 'PUT',
+      method: 'PATCH',
       body: JSON.stringify(data),
       credentials: 'same-origin',
       headers: {

--- a/lib/frontend/src/components/MeetingReport/ReportItems.jsx
+++ b/lib/frontend/src/components/MeetingReport/ReportItems.jsx
@@ -165,7 +165,11 @@ function ReportItems(props) {
                         onIndicatorsChange(event.target)
                       }}
                       type="number"
-                      value={indicator.value === null ? '' : indicator.value}
+                      value={
+                        indicator.value === null || isNaN(indicator.value)
+                          ? ''
+                          : indicator.value
+                      }
                     />
                   </td>
                   <td>

--- a/lib/frontend/src/reducer/gibolt.js
+++ b/lib/frontend/src/reducer/gibolt.js
@@ -101,6 +101,19 @@ export const meeting = (state = initial.meeting, action) => {
           [action.dataType]: action.data,
         },
       }
+    case 'MEETING_PARTIAL_UPDATE':
+      return {
+        ...state,
+        results: {
+          ...state.results,
+          report_id: action.data.report_id,
+          circle_id: action.data.circle_id,
+          created_at: action.data.created_at,
+          author_id: action.data.author_id,
+          modified_at: action.data.modified_at,
+          modified_by: action.data.modified_by,
+        },
+      }
     case 'MEETING_UPDATE_ATTENDEES':
       return {
         ...state,


### PR DESCRIPTION
**Actions réalisées :**
* Mise à jour d'un rôle : correction de l'erreur à la mise à jour,
* Rédaction d'un rapport : lors de la sauvegarde du draft (cas où le rapport n'est pas soumis), les inputs ne sont plus rafraîchis en retour (évite de perdre le texte saisi entre la sauvegarde et le refresh).