### PR TITLE
Issues Presets

### DIFF
--- a/lib/frontend/src/components/App.jsx
+++ b/lib/frontend/src/components/App.jsx
@@ -4,7 +4,7 @@ import React, { Component } from 'react'
 import { Helmet } from 'react-helmet'
 import { Route, Switch } from 'react-router-dom'
 
-import { block } from '../utils'
+import { block, connect } from '../utils'
 import Admin from './Admin'
 import Circle from './Circle'
 import Circles from './Circles'
@@ -24,20 +24,21 @@ import Timeline from './Timeline'
 
 const b = block('App')
 
-export default class App extends Component {
+class App extends Component {
   constructor(props) {
     super(props)
     this.props = props
   }
 
   render() {
+    const { location } = this.props
     return (
       <main className={b()}>
         <Helmet>
           <title>Gibolt</title>
         </Helmet>
         <Presets />
-        <IssuesPresets />
+        {location.pathname === '/' && <IssuesPresets />}
         <Switch>
           <Route exact path="/" component={IssuesDashboard} />
           <Route path="/admin" component={Admin} />
@@ -58,3 +59,5 @@ export default class App extends Component {
     )
   }
 }
+
+export default connect(() => ({}))(App)

--- a/lib/frontend/src/components/App.jsx
+++ b/lib/frontend/src/components/App.jsx
@@ -11,6 +11,7 @@ import Circles from './Circles'
 import CreateCircle from './CreateCircle'
 import CreateRole from './CreateRole'
 import IssuesDashboard from './IssuesDashboard'
+import IssuesPresets from './IssuesPresets'
 import Meeting from './Meeting'
 import MeetingReportCreation from './MeetingReportCreation'
 import Meetings from './Meetings'
@@ -36,6 +37,7 @@ export default class App extends Component {
           <title>Gibolt</title>
         </Helmet>
         <Presets />
+        <IssuesPresets />
         <Switch>
           <Route exact path="/" component={IssuesDashboard} />
           <Route path="/admin" component={Admin} />

--- a/lib/frontend/src/components/Issues.sass
+++ b/lib/frontend/src/components/Issues.sass
@@ -5,6 +5,31 @@
   overflow: auto
   position: relative
 
+  &__accordion
+    background-color: #F0F5F9
+    border: none
+    color: #717171
+    cursor: pointer
+    font-size: .9em
+    font-weight: bold
+    height: 1em
+    margin-right: .1em
+    padding: 0
+    transition: 0.4s
+    width: 1em
+
+    &:hover
+      background-color: #ccc
+
+  &__check
+    align-items: center
+    color: #50595f
+    display: flex
+    margin: 1em
+
+    input
+      margin-right: .5em
+
   &__head
     align-items: center
     background: $issues-header
@@ -41,6 +66,13 @@
     position: fixed
     right: 0
     top: 0
+
+  &__panel
+    &__display
+      display: block
+
+    &__hidden
+      display: none
 
   &__newTicket
     background: #bac9d5

--- a/lib/frontend/src/components/IssuesPresets.jsx
+++ b/lib/frontend/src/components/IssuesPresets.jsx
@@ -1,0 +1,77 @@
+import './IssuesPresets.sass'
+
+import equal from 'deep-equal'
+import { parse, stringify } from 'query-string'
+import React from 'react'
+
+import { block, connect } from '../utils'
+import Preset from './Preset'
+
+const PRESETS = ({ login }) => ({
+  urgent: {
+    state: 'all',
+    grouper: 'state',
+    priority: 'Urgent',
+    ack: '',
+    assignee: login,
+  },
+  my_tickets: {
+    state: 'open',
+    grouper: 'project',
+    priority: '',
+    ack: '',
+    assignee: '',
+    involves: login,
+  },
+  sprint_issues: {
+    state: 'all',
+    grouper: 'nogroup',
+    priority: 'sprint',
+    ack: '',
+    assignee: '',
+  },
+})
+
+const b = block('IssuesPresets')
+function IssuesPresets({ location, user }) {
+  const userPreset = PRESETS(user)
+  const query = parse(location.search)
+  return (
+    <span className={b()}>
+      <ul>
+        <Preset
+          action={{ pathname: '/', search: stringify(userPreset.urgent) }}
+          active={
+            location.pathname === '/' &&
+            equal({ ...userPreset.urgent, ...query }, userPreset.urgent)
+          }
+        >
+          My urgency
+        </Preset>
+        <Preset
+          action={{ pathname: '/', search: stringify(userPreset.my_tickets) }}
+          active={
+            location.pathname === '/' && equal(query, userPreset.my_tickets)
+          }
+        >
+          My Tickets
+        </Preset>
+        <Preset
+          action={{
+            pathname: '/',
+            search: stringify(userPreset.sprint_issues),
+          }}
+          active={
+            location.pathname === '/' && equal(query, userPreset.sprint_issues)
+          }
+        >
+          No presets
+        </Preset>
+      </ul>
+    </span>
+  )
+}
+
+export default connect(state => ({
+  user: state.user,
+}))(IssuesPresets)

--- a/lib/frontend/src/components/IssuesPresets.jsx
+++ b/lib/frontend/src/components/IssuesPresets.jsx
@@ -15,9 +15,25 @@ const PRESETS = ({ login }) => ({
     ack: '',
     assignee: login,
   },
-  my_tickets: {
+  my_open_tickets: {
     state: 'open',
     grouper: 'project',
+    priority: '',
+    ack: '',
+    assignee: login,
+    involves: '',
+  },
+  all_my_tickets: {
+    state: 'open',
+    grouper: 'project',
+    priority: '',
+    ack: '',
+    assignee: '',
+    involves: login,
+  },
+  my_milestones: {
+    state: 'all',
+    grouper: 'milestone',
     priority: '',
     ack: '',
     assignee: '',
@@ -49,12 +65,38 @@ function IssuesPresets({ location, user }) {
           My urgency
         </Preset>
         <Preset
-          action={{ pathname: '/', search: stringify(userPreset.my_tickets) }}
+          action={{
+            pathname: '/',
+            search: stringify(userPreset.my_open_tickets),
+          }}
           active={
-            location.pathname === '/' && equal(query, userPreset.my_tickets)
+            location.pathname === '/' &&
+            equal(query, userPreset.my_open_tickets)
           }
         >
-          My Tickets
+          My Open Tickets
+        </Preset>
+        <Preset
+          action={{
+            pathname: '/',
+            search: stringify(userPreset.all_my_tickets),
+          }}
+          active={
+            location.pathname === '/' && equal(query, userPreset.all_my_tickets)
+          }
+        >
+          All My Tickets
+        </Preset>
+        <Preset
+          action={{
+            pathname: '/',
+            search: stringify(userPreset.my_milestones),
+          }}
+          active={
+            location.pathname === '/' && equal(query, userPreset.my_milestones)
+          }
+        >
+          My Milestones
         </Preset>
         <Preset
           action={{

--- a/lib/frontend/src/components/IssuesPresets.sass
+++ b/lib/frontend/src/components/IssuesPresets.sass
@@ -1,10 +1,9 @@
 @import ../vars
 
 .IssuesPresets
-  background: #2c4065
-  color: #fff
+  background: #2c3957
   display: flex
-  flex-flow: row wrap
+  font-size: 0.9em
   width: 100%
 
   ul

--- a/lib/frontend/src/components/IssuesPresets.sass
+++ b/lib/frontend/src/components/IssuesPresets.sass
@@ -1,0 +1,13 @@
+@import ../vars
+
+.IssuesPresets
+  background: #2c4065
+  color: #fff
+  display: flex
+  flex-flow: row wrap
+  width: 100%
+
+  ul
+    align-items: stretch
+    display: flex
+    margin: 0

--- a/lib/frontend/src/components/Presets.jsx
+++ b/lib/frontend/src/components/Presets.jsx
@@ -1,41 +1,12 @@
 import './Presets.sass'
 
-import equal from 'deep-equal'
-import { parse, stringify } from 'query-string'
 import React from 'react'
 
 import { block, connect } from '../utils'
 import Preset from './Preset'
 
-const PRESETS = ({ login }) => ({
-  urgent: {
-    state: 'all',
-    grouper: 'state',
-    priority: 'Urgent',
-    ack: '',
-    assignee: login,
-  },
-  my_tickets: {
-    state: 'open',
-    grouper: 'project',
-    priority: '',
-    ack: '',
-    assignee: '',
-    involves: login,
-  },
-  sprint_issues: {
-    state: 'all',
-    grouper: 'nogroup',
-    priority: 'sprint',
-    ack: '',
-    assignee: '',
-  },
-})
-
 const b = block('Presets')
-function Presets({ location, user }) {
-  const userPreset = PRESETS(user)
-  const query = parse(location.search)
+function Presets({ location }) {
   return (
     <header className={b()}>
       <h1 className={b('title')}>
@@ -45,37 +16,11 @@ function Presets({ location, user }) {
       </h1>
       <nav>
         <ul className={b('nav')}>
-          <Preset
-            action={{ pathname: '/', search: stringify(userPreset.urgent) }}
-            active={
-              location.pathname === '/' &&
-              equal({ ...userPreset.urgent, ...query }, userPreset.urgent)
-            }
-          >
-            My urgency
-          </Preset>
-          <Preset
-            action={{ pathname: '/', search: stringify(userPreset.my_tickets) }}
-            active={
-              location.pathname === '/' && equal(query, userPreset.my_tickets)
-            }
-          >
-            My Tickets
+          <Preset action={{ pathname: '/' }} active={location.pathname === '/'}>
+            Issues
           </Preset>
           <Preset action="/timeline" active={location.pathname === '/timeline'}>
             Timeline
-          </Preset>
-          <Preset
-            action={{
-              pathname: '/',
-              search: stringify(userPreset.sprint_issues),
-            }}
-            active={
-              location.pathname === '/' &&
-              equal(query, userPreset.sprint_issues)
-            }
-          >
-            Issues
           </Preset>
           <Preset action="/report" active={location.pathname === '/report'}>
             Report

--- a/lib/frontend/src/utils.js
+++ b/lib/frontend/src/utils.js
@@ -171,7 +171,7 @@ export const sortIssues = issues =>
 
 export const sortGroupIssues = (issues, grouper) => {
   if (grouper === 'state') {
-    return issues.sort(a => (a.group === 'open' && 1) || -1)
+    return issues.sort(a => (a.group === 'open' && -1) || 1)
   }
   return issues.sort((a, b) => {
     if (a.group.toLowerCase() < b.group.toLowerCase()) {


### PR DESCRIPTION
**Actions effectuées**:
* Les filtres sur les Issues disposent de leur propre sous-menu. Le filtre '**My Tickets**' est renommé '**All My Tickets**'
* Dans le cas où les tickets sont groupés par état, les tickets ouverts apparaissent en premier.
* 2 nouveaux filtres ont été ajoutés:
  * '**My Open Tickets**': tous les tickets ouverts auxquels l'utilisateur connecté est assigné, groupés par projet, quelque soit la priorité
  * '**My Milestones**': tous les tickets sur lesquels l'utilisateur connecté est impliqué, groupés par _milestone_
* Il est possible de masquer les tickets pour n'afficher que les titres des groupes
![capture du 2018-03-29 11-51-38](https://user-images.githubusercontent.com/3525167/38082646-9a391080-3347-11e8-9bcb-f524cc4cfee6.png)
