### PR TITLE
Les focus ne sont pas affichés si aucun n'est nommé

### DIFF
--- a/gibolt/templates/circle/roles.html.jinja2
+++ b/gibolt/templates/circle/roles.html.jinja2
@@ -7,7 +7,7 @@
       <h4>{{ {'leadlink': 'Premier lien', 'elected': 'Rôles élus', 'assigned': 'Rôles assignés'}[role_type] }}</h4>
       {% for role in roles | sort(attribute='role_name') %}
         <section class="role">
-          {% if role.role_focuses | map(attribute='focus_name') | join %}
+          {% if role.role_focuses | length > 1 %}
             <a href="{{ url_for('circle_role', role_id=role.role_id) }}">{{ role.role_name }}</a>
             <ul>
               {% for focus in role.role_focuses %}


### PR DESCRIPTION
![Selection_004](https://user-images.githubusercontent.com/137324/75028858-56be4780-54a1-11ea-90b2-088af32dd297.png)

État actuel : seul le premier focus est affiché.

![Selection_003](https://user-images.githubusercontent.com/137324/75028888-650c6380-54a1-11ea-9733-bc8216d44e77.png)

Version de la PR : tous les focus sont affichés.

![Selection_005](https://user-images.githubusercontent.com/137324/75028948-81a89b80-54a1-11ea-9908-4faff0ccc714.png)

